### PR TITLE
Add iOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# TrackEase Subscription Tracker
+
+This project is built with [Expo](https://expo.dev/) and React Native.
+
+## Running on iOS
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Generate native iOS project files:
+   ```bash
+   npx expo prebuild --platform ios
+   ```
+3. Open the generated `ios/TrackEase.xcworkspace` in Xcode.
+4. Set up signing and run the application on a simulator or real device.
+
+These steps require the Expo CLI and Xcode.


### PR DESCRIPTION
## Summary
- add a basic README with steps for generating the iOS project using Expo CLI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685752cd3720832d94799e0a02809d26